### PR TITLE
Support encoding vertical tabs

### DIFF
--- a/jsonwriter.go
+++ b/jsonwriter.go
@@ -29,6 +29,7 @@ var (
 	escapedNL    = []byte(`\n`)
 	escapedLF    = []byte(`\r`)
 	escapedTab   = []byte(`\t`)
+	escapedVTab  = []byte(`\u000b`)
 )
 
 type Writer struct {
@@ -297,6 +298,8 @@ L:
 			special = escapedLF
 		case '\t':
 			special = escapedTab
+		case '\v':
+			special = escapedVTab
 		default:
 			end += utf8.RuneLen(r)
 			continue L

--- a/jsonwriter_test.go
+++ b/jsonwriter_test.go
@@ -39,6 +39,7 @@ func (_ WriterTests) WritesAString() {
 	assertValue(`ab"cd`, `"ab\"cd"`)
 	assertValue(`💣`, `"💣"`)
 	assertValue("\\it's\n\tOver\r9000!\\ 💣 💣 💣", `"\\it's\n\tOver\r9000!\\ 💣 💣 💣"`)
+	assertValue("vertical\vtab", `"vertical\u000btab"`)
 }
 
 func (_ WriterTests) WritesABool() {


### PR DESCRIPTION
Vertical tabs don’t have a special escape character as defined by the [JSON spec](http://json.org/) but are rejected by strict JSON parsers (eg the standard JavaScript `JSON.parse`) as being literal control characters.

This adds support for automatically encoding literal vertical tabs (`\v`) as escaped Unicode character `\u000b` in the output JSON. This means that users of this library don’t need to manually ensure vertical tabs are escaped.